### PR TITLE
Feat(#3): Docker-compose에 DB를 추가하고 DB를 테스트 할 수 있는 컨트롤러를 만든다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 apply from: "./gradle/spring.gradle"
 apply from: "./gradle/swagger.gradle"
+apply from: "./gradle/db.gradle"
 
 tasks.named('test') {
     useJUnitPlatform()

--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -6,11 +6,31 @@ services:
       dockerfile: Dockerfile-local
     ports:
       - "8080:8080"
-    environment:
-      SPRING_PROFILES_ACTIVE: local
     networks:
       - app-network
+    depends_on:
+      - db
+
+  db:
+    container_name: db
+    image: "mysql:8.0"
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: 1234
+      MYSQL_DATABASE: capstone
+      MYSQL_USER: dev_capstone
+      MYSQL_PASSWORD: 1234
+    ports:
+      - "3307:3306"
+    networks:
+      - app-network
+    volumes:
+      - mysql-data:/var/lib/mysql
+
 
 networks:
   app-network:
     driver: bridge
+
+volumes:
+  mysql-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,8 +6,29 @@ services:
       - "8080:8080"
     networks:
       - app-network
+    depends_on:
+      - db
+
+  db:
+    container_name: db
+    image: "mysql:8.0"
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: 1234
+      MYSQL_DATABASE: capstone
+      MYSQL_USER: dev_capstone
+      MYSQL_PASSWORD: 1234
+    ports:
+      - "3306:3306"
+    networks:
+      - app-network
+    volumes:
+      - mysql-data:/var/lib/mysql
 
 
 networks:
   app-network:
     driver: bridge
+
+volumes:
+  mysql-data:

--- a/gradle/db.gradle
+++ b/gradle/db.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    implementation 'com.mysql:mysql-connector-j:8.0.33'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+}

--- a/gradle/db.gradle
+++ b/gradle/db.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    // MySQL 관련 gradle
     implementation 'com.mysql:mysql-connector-j:8.0.33'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 }

--- a/src/main/java/com/noraknorak/core/configuration/swagger/SwaggerConfiguration.java
+++ b/src/main/java/com/noraknorak/core/configuration/swagger/SwaggerConfiguration.java
@@ -24,8 +24,10 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @Configuration
-@OpenAPIDefinition(info = @Info(title = "노락노락 API", description = "노락노락 : API 명세서", version = "v1.0.0"),
-        servers = {@Server(url = "${springdoc.server-url}", description = "Https Server URL")})
+@OpenAPIDefinition(
+        info = @Info(title = "어르심 API", description = "머르심 : API 명세서", version = "v1.0.0"),
+        servers = {@Server(url = "${springdoc.server-url}", description = "Https Server URL")}
+)
 public class SwaggerConfiguration {
     @Bean
     public OpenAPI openAPI(){

--- a/src/main/java/com/noraknorak/core/presentation/controller/DatabaseController.java
+++ b/src/main/java/com/noraknorak/core/presentation/controller/DatabaseController.java
@@ -1,0 +1,39 @@
+package com.noraknorak.core.presentation.controller;
+
+import com.noraknorak.core.presentation.swagger.DBTestSwagger;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+@RestController
+@RequestMapping("/db")
+@RequiredArgsConstructor
+public class DatabaseController implements DBTestSwagger {
+
+    private final DataSource dataSource;
+
+    @Override
+    @GetMapping("/test")
+    public String testDatabaseConnection() {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("SELECT NOW()")) {
+
+            if (resultSet.next()) {
+                return "DB 연결 성공! 현재 시간: " + resultSet.getString(1);
+            } else {
+                return "DB 연결은 되었지만 데이터를 가져오지 못했습니다.";
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "DB 연결 실패: " + e.getMessage();
+        }
+    }
+}

--- a/src/main/java/com/noraknorak/core/presentation/controller/HealthController.java
+++ b/src/main/java/com/noraknorak/core/presentation/controller/HealthController.java
@@ -1,5 +1,6 @@
-package com.noraknorak.core.presentation;
+package com.noraknorak.core.presentation.controller;
 
+import com.noraknorak.core.presentation.RestResponse;
 import com.noraknorak.core.presentation.swagger.HealthSwagger;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/noraknorak/core/presentation/swagger/DBTestSwagger.java
+++ b/src/main/java/com/noraknorak/core/presentation/swagger/DBTestSwagger.java
@@ -1,0 +1,14 @@
+package com.noraknorak.core.presentation.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "DB", description = "DB 테스트")
+public interface DBTestSwagger {
+    @Operation(
+            summary = "DB Test API",
+            description = "현재 데이터 베이스가 연결 되어 있는지 확인합니다.",
+            operationId = "/db/test"
+    )
+    public String testDatabaseConnection();
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [x] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- docker-compose에 MySQL을 추가하여 컨테이너화 하였습니다(영구 데이터 저장을 위한 볼륨도 추가함)
- 그에 관련한 Swagger용 테스트 컨트롤러를 만들었습니다.

---

## ✏️ 관련 이슈
#3 

---

## 🎸 기타 사항 or 추가 코멘트
- application.yml 파일의 변경으로 인한 수정이 필요합니다.
- local 실행시에는 여전히 docker-compose-local을 실행하여 사용하시면 됩니다.