### PR TITLE
Feat(#53): 토큰 재발급 로직 추가 및 토큰 관리 방식 변경

### DIFF
--- a/src/main/java/com/noraknorak/auth/application/LoginService.java
+++ b/src/main/java/com/noraknorak/auth/application/LoginService.java
@@ -20,9 +20,10 @@ public class LoginService {
                 .orElseThrow(() -> UserErrorCode.USER_NOT_FOUND.toException());
 
         String accessToken = tokenService.provideAccessToken(new TokenRequest(user.getId()));
+        String refreshToken = tokenService.provideRefreshToken(new TokenRequest(user.getId()));
 
         return TokenResponse.of(
-                accessToken, user
+                accessToken, refreshToken, user
         );
     }
 }

--- a/src/main/java/com/noraknorak/auth/application/RefreshTokenService.java
+++ b/src/main/java/com/noraknorak/auth/application/RefreshTokenService.java
@@ -1,0 +1,33 @@
+package com.noraknorak.auth.application;
+
+import com.noraknorak.auth.infrastructure.JwtProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final JwtProperties jwtProperties;
+
+    private static final String PREFIX = "RT:";
+
+    public void save(Long userId, String refreshToken) {
+        long ttl = jwtProperties.getRefreshExpiration();
+        redisTemplate.opsForValue()
+                .set(PREFIX + userId, refreshToken, ttl, TimeUnit.DAYS);
+    }
+
+    public boolean isValid(Long userId, String token) {
+        Object stored = redisTemplate.opsForValue().get(PREFIX + userId);
+        return token.equals(stored);
+    }
+
+    public void delete(Long userId) {
+        redisTemplate.delete(PREFIX + userId);
+    }
+}

--- a/src/main/java/com/noraknorak/auth/application/TokenService.java
+++ b/src/main/java/com/noraknorak/auth/application/TokenService.java
@@ -20,4 +20,11 @@ public class TokenService {
                 .orElseThrow(UserErrorCode.USER_NOT_FOUND::toException);
         return tokenProvider.provideAccessToken(user);
     }
+
+    public String provideRefreshToken(TokenRequest request) {
+        User user = userRepository.findById(request.userId())
+                .orElseThrow(UserErrorCode.USER_NOT_FOUND::toException);
+
+        return tokenProvider.provideRefreshToken(user);
+    }
 }

--- a/src/main/java/com/noraknorak/auth/application/TokenService.java
+++ b/src/main/java/com/noraknorak/auth/application/TokenService.java
@@ -27,4 +27,8 @@ public class TokenService {
 
         return tokenProvider.provideRefreshToken(user);
     }
+
+    public Long getUserId(String token){
+        return tokenProvider.getUserId(token);
+    }
 }

--- a/src/main/java/com/noraknorak/auth/domain/TokenProvider.java
+++ b/src/main/java/com/noraknorak/auth/domain/TokenProvider.java
@@ -4,4 +4,5 @@ import com.noraknorak.user.domain.User;
 
 public interface TokenProvider {
     String provideAccessToken(User user);
+    String provideRefreshToken(User user);
 }

--- a/src/main/java/com/noraknorak/auth/domain/TokenProvider.java
+++ b/src/main/java/com/noraknorak/auth/domain/TokenProvider.java
@@ -5,4 +5,5 @@ import com.noraknorak.user.domain.User;
 public interface TokenProvider {
     String provideAccessToken(User user);
     String provideRefreshToken(User user);
+    Long getUserId(String token);
 }

--- a/src/main/java/com/noraknorak/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/noraknorak/auth/dto/response/TokenResponse.java
@@ -5,9 +5,10 @@ import com.noraknorak.user.domain.User;
 public record TokenResponse(
         String accessToken,
         String refreshToken,
+        Long userId,
         String userName
 ) {
     public static TokenResponse of(String accessToken, String refreshToken, User user) {
-        return new TokenResponse(accessToken, refreshToken, user.getName());
+        return new TokenResponse(accessToken, refreshToken, user.getId(), user.getName());
     }
 }

--- a/src/main/java/com/noraknorak/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/noraknorak/auth/dto/response/TokenResponse.java
@@ -4,12 +4,10 @@ import com.noraknorak.user.domain.User;
 
 public record TokenResponse(
         String accessToken,
-//        String refreshToken,
-        
-        // TODO: 프론트와 상의 후 무슨 정보 줄지 정하기
-        User user
+        String refreshToken,
+        String userName
 ) {
-    public static TokenResponse of(String accessToken, User user) {
-        return new TokenResponse(accessToken, user);
+    public static TokenResponse of(String accessToken, String refreshToken, User user) {
+        return new TokenResponse(accessToken, refreshToken, user.getName());
     }
 }

--- a/src/main/java/com/noraknorak/auth/exception/AuthenticationErrorCode.java
+++ b/src/main/java/com/noraknorak/auth/exception/AuthenticationErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AuthenticationErrorCode implements BaseErrorCode<DomainException> {
+    EMPTY_TOKEN(HttpStatus.NOT_FOUND, "토큰이 존재하지 않습니다."),
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),

--- a/src/main/java/com/noraknorak/auth/infrastructure/CookieGenerator.java
+++ b/src/main/java/com/noraknorak/auth/infrastructure/CookieGenerator.java
@@ -9,10 +9,10 @@ import org.springframework.stereotype.Component;
 public class CookieGenerator {
     private final JwtProperties jwtProperties;
 
-    public ResponseCookie generateCookie(String content) {
+    public ResponseCookie generateCookie(String cookieName, String content) {
         long accessCookieMaxAge = jwtProperties.getAccessExpiration() / 1000; // 쿠키 유효시간 1시간
 
-        return ResponseCookie.from("AccessToken", content)
+        return ResponseCookie.from(cookieName, content)
                 .path("/")
                 .httpOnly(true)
                 .secure(true)

--- a/src/main/java/com/noraknorak/auth/infrastructure/JwtTokenProvider.java
+++ b/src/main/java/com/noraknorak/auth/infrastructure/JwtTokenProvider.java
@@ -80,6 +80,7 @@ public class JwtTokenProvider implements TokenProvider {
         }
     }
 
+    @Override
     public Long getUserId(String token) {
         return Long.parseLong(getPayload(token).getSubject());
     }
@@ -98,7 +99,8 @@ public class JwtTokenProvider implements TokenProvider {
         } else {
             expiryDate = Date.from(Instant.now().plus(expiration, ChronoUnit.DAYS));
             claims = Map.of(
-                    "type", type.getType()
+                    "type", type.getType(),
+                    "sub", user.getId().toString()
             );
         }
 

--- a/src/main/java/com/noraknorak/auth/presentation/LoginController.java
+++ b/src/main/java/com/noraknorak/auth/presentation/LoginController.java
@@ -1,6 +1,7 @@
 package com.noraknorak.auth.presentation;
 
 import com.noraknorak.auth.application.LoginService;
+import com.noraknorak.auth.application.RefreshTokenService;
 import com.noraknorak.auth.dto.request.LoginRequest;
 import com.noraknorak.auth.dto.response.TokenResponse;
 import com.noraknorak.auth.infrastructure.CookieGenerator;
@@ -19,8 +20,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("v1/auth")
 @RequiredArgsConstructor
 public class LoginController implements LoginSwagger{
+
     private final LoginService loginService;
     private final CookieGenerator cookieGenerator;
+    private final RefreshTokenService refreshTokenService;
 
     @Override
     @PostMapping("/login")
@@ -29,8 +32,10 @@ public class LoginController implements LoginSwagger{
         String accessToken = tokenResponse.accessToken();
         String refreshToken = tokenResponse.refreshToken();
 
-        ResponseCookie accessCookie = cookieGenerator.generateCookie("AccessToken", accessToken);
-        ResponseCookie refreshCookie = cookieGenerator.generateCookie("RefreshToken", refreshToken);
+        refreshTokenService.save(tokenResponse.userId(), refreshToken);
+
+        ResponseCookie accessCookie = cookieGenerator.generateCookie("accessToken", accessToken);
+        ResponseCookie refreshCookie = cookieGenerator.generateCookie("refreshToken", refreshToken);
 
         return ResponseEntity
                 .ok()

--- a/src/main/java/com/noraknorak/auth/presentation/LoginController.java
+++ b/src/main/java/com/noraknorak/auth/presentation/LoginController.java
@@ -27,11 +27,15 @@ public class LoginController implements LoginSwagger{
     public ResponseEntity<RestResponse<TokenResponse>> login(@Valid @RequestBody LoginRequest loginRequest) {
         TokenResponse tokenResponse = loginService.login(loginRequest);
         String accessToken = tokenResponse.accessToken();
+        String refreshToken = tokenResponse.refreshToken();
 
-        ResponseCookie cookie = cookieGenerator.generateCookie(accessToken);
+        ResponseCookie accessCookie = cookieGenerator.generateCookie("AccessToken", accessToken);
+        ResponseCookie refreshCookie = cookieGenerator.generateCookie("RefreshToken", refreshToken);
+
         return ResponseEntity
                 .ok()
-                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
                 .body(new RestResponse<>(tokenResponse));
     }
 }

--- a/src/main/java/com/noraknorak/auth/presentation/LogoutController.java
+++ b/src/main/java/com/noraknorak/auth/presentation/LogoutController.java
@@ -1,10 +1,13 @@
 package com.noraknorak.auth.presentation;
 
+import com.noraknorak.auth.application.RefreshTokenService;
+import com.noraknorak.core.infrastructure.security.CustomUserDetails;
 import com.noraknorak.core.presentation.RestResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,9 +17,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class LogoutController implements LogoutSwagger {
 
+    private final RefreshTokenService refreshTokenService;
+
     @PostMapping("/logout")
-    public ResponseEntity<RestResponse<Void>> logout() {
-        ResponseCookie cookie = ResponseCookie.from("accessToken", "")
+    public ResponseEntity<RestResponse<Void>> logout(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        ResponseCookie cookie1 = ResponseCookie.from("accessToken", "")
                 .path("/")
                 .httpOnly(true)
                 .secure(true)
@@ -24,8 +31,19 @@ public class LogoutController implements LogoutSwagger {
                 .maxAge(0)
                 .build();
 
+        ResponseCookie cookie2 = ResponseCookie.from("refreshToken", "")
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .maxAge(0)
+                .build();
+
+        refreshTokenService.delete(customUserDetails.getId());
+
         return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .header(HttpHeaders.SET_COOKIE, cookie1.toString())
+                .header(HttpHeaders.SET_COOKIE, cookie2.toString())
                 .build();
     }
 }

--- a/src/main/java/com/noraknorak/auth/presentation/LogoutSwagger.java
+++ b/src/main/java/com/noraknorak/auth/presentation/LogoutSwagger.java
@@ -1,10 +1,12 @@
 package com.noraknorak.auth.presentation;
 
 import com.noraknorak.core.config.swagger.ApiErrorCode;
+import com.noraknorak.core.infrastructure.security.CustomUserDetails;
 import com.noraknorak.core.presentation.RestResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 @Tag(name = "Auth", description = "로그인/회원가입 관련 컨트롤러")
 public interface LogoutSwagger {
@@ -14,5 +16,7 @@ public interface LogoutSwagger {
             operationId = "v1/auth/logout"
     )
     @ApiErrorCode({})
-    ResponseEntity<RestResponse<Void>> logout();
+    ResponseEntity<RestResponse<Void>> logout(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    );
 }

--- a/src/main/java/com/noraknorak/user/application/UserRegisterService.java
+++ b/src/main/java/com/noraknorak/user/application/UserRegisterService.java
@@ -1,5 +1,9 @@
 package com.noraknorak.user.application;
 
+import com.noraknorak.auth.application.RefreshTokenService;
+import com.noraknorak.auth.application.TokenService;
+import com.noraknorak.auth.dto.request.TokenRequest;
+import com.noraknorak.auth.exception.AuthenticationErrorCode;
 import com.noraknorak.sms.domain.AuthCodeManager;
 import com.noraknorak.user.domain.User;
 import com.noraknorak.user.domain.repository.UserRepository;
@@ -8,6 +12,7 @@ import com.noraknorak.user.domain.value.UserCodeGenerator;
 import com.noraknorak.user.exception.UserErrorCode;
 import com.noraknorak.user.presentation.dto.request.UserSignUpRequest;
 import com.noraknorak.user.presentation.dto.request.UserVerifyCodeRequest;
+import com.noraknorak.user.presentation.dto.response.UserNewTokenResponse;
 import com.noraknorak.user.presentation.dto.response.UserSignUpResult;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +26,8 @@ public class UserRegisterService {
 
     private final UserRepository userRepository;
     private final AuthCodeManager authCodeManager;
+    private final TokenService tokenService;
+    private final RefreshTokenService refreshTokenService;
 
     //유저 등록
     @Transactional
@@ -77,5 +84,25 @@ public class UserRegisterService {
             return true;
         }
         throw UserErrorCode.NOT_EQUAL_CODE.toException();
+    }
+
+    @Transactional
+    public UserNewTokenResponse issueNewToken(String refreshToken){
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw AuthenticationErrorCode.EMPTY_TOKEN.toException();
+        }
+
+        Long id = tokenService.getUserId(refreshToken);
+
+        User user = userRepository.findById(id)
+                .orElseThrow(UserErrorCode.USER_NOT_FOUND::toException);
+
+        String newAccessToken = tokenService.provideAccessToken(new TokenRequest(user.getId()));
+        String newRefreshToken = tokenService.provideRefreshToken(new TokenRequest(user.getId()));
+
+        refreshTokenService.delete(user.getId());
+        refreshTokenService.save(user.getId(), newRefreshToken);
+
+        return UserNewTokenResponse.of(newAccessToken, newRefreshToken);
     }
 }

--- a/src/main/java/com/noraknorak/user/presentation/controller/UserRegisterController.java
+++ b/src/main/java/com/noraknorak/user/presentation/controller/UserRegisterController.java
@@ -3,10 +3,12 @@ package com.noraknorak.user.presentation.controller;
 import com.noraknorak.auth.application.RefreshTokenService;
 import com.noraknorak.auth.infrastructure.CookieGenerator;
 import com.noraknorak.auth.infrastructure.JwtTokenProvider;
+import com.noraknorak.core.infrastructure.security.CustomUserDetails;
 import com.noraknorak.core.presentation.RestResponse;
 import com.noraknorak.user.domain.User;
 import com.noraknorak.user.presentation.dto.request.UserSignUpRequest;
 import com.noraknorak.user.presentation.dto.request.UserVerifyCodeRequest;
+import com.noraknorak.user.presentation.dto.response.UserNewTokenResponse;
 import com.noraknorak.user.presentation.dto.response.UserSignUpResponse;
 import com.noraknorak.user.presentation.dto.response.UserSignUpResult;
 import com.noraknorak.user.presentation.swagger.UserRegisterSwagger;
@@ -16,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -58,5 +61,21 @@ public class UserRegisterController implements UserRegisterSwagger {
     public ResponseEntity<RestResponse<Boolean>> verifyCode(@Valid @RequestBody UserVerifyCodeRequest userVerifyCodeRequest) {
         boolean result = userRegisterService.verifyCode(userVerifyCodeRequest);
         return ResponseEntity.ok(new RestResponse<>(result));
+    }
+
+    @Override
+    @PostMapping("reissue")
+    public ResponseEntity<RestResponse<UserNewTokenResponse>> issueNewToken(
+            @RequestHeader(value = "refreshToken", required = false) String refreshToken
+    ) {
+        UserNewTokenResponse response = userRegisterService.issueNewToken(refreshToken);
+
+        ResponseCookie accessCookie = cookieGenerator.generateCookie("accessToken", response.accessToken());
+        ResponseCookie refreshCookie = cookieGenerator.generateCookie("refreshToken", response.refreshToken());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
+                .body(new RestResponse<>(response));
     }
 }

--- a/src/main/java/com/noraknorak/user/presentation/controller/UserRegisterController.java
+++ b/src/main/java/com/noraknorak/user/presentation/controller/UserRegisterController.java
@@ -1,5 +1,6 @@
 package com.noraknorak.user.presentation.controller;
 
+import com.noraknorak.auth.application.RefreshTokenService;
 import com.noraknorak.auth.infrastructure.CookieGenerator;
 import com.noraknorak.auth.infrastructure.JwtTokenProvider;
 import com.noraknorak.core.presentation.RestResponse;
@@ -25,6 +26,7 @@ public class UserRegisterController implements UserRegisterSwagger {
     private final UserRegisterService userRegisterService;
     private final JwtTokenProvider jwtTokenProvider;
     private final CookieGenerator cookieGenerator;
+    private final RefreshTokenService refreshTokenService;
 
     @Override
     @PostMapping("/sign-up")
@@ -37,10 +39,12 @@ public class UserRegisterController implements UserRegisterSwagger {
         String accessToken = jwtTokenProvider.provideAccessToken(user);
         String refreshToken = jwtTokenProvider.provideRefreshToken(user);
 
+        refreshTokenService.save(user.getId(), refreshToken);
+
         UserSignUpResponse response = UserSignUpResponse.from(accessToken, refreshToken, user, isNewUser);
 
-        ResponseCookie accessCookie = cookieGenerator.generateCookie("AccessToken", accessToken);
-        ResponseCookie refreshCookie = cookieGenerator.generateCookie("RefreshToken", refreshToken);
+        ResponseCookie accessCookie = cookieGenerator.generateCookie("accessToken", accessToken);
+        ResponseCookie refreshCookie = cookieGenerator.generateCookie("refreshToken", refreshToken);
 
         return ResponseEntity
                 .ok()

--- a/src/main/java/com/noraknorak/user/presentation/controller/UserRegisterController.java
+++ b/src/main/java/com/noraknorak/user/presentation/controller/UserRegisterController.java
@@ -35,13 +35,17 @@ public class UserRegisterController implements UserRegisterSwagger {
         boolean isNewUser = result.isNewUser();
 
         String accessToken = jwtTokenProvider.provideAccessToken(user);
+        String refreshToken = jwtTokenProvider.provideRefreshToken(user);
 
-        UserSignUpResponse response = UserSignUpResponse.from(accessToken, user, isNewUser);
+        UserSignUpResponse response = UserSignUpResponse.from(accessToken, refreshToken, user, isNewUser);
 
-        ResponseCookie cookie = cookieGenerator.generateCookie(accessToken);
+        ResponseCookie accessCookie = cookieGenerator.generateCookie("AccessToken", accessToken);
+        ResponseCookie refreshCookie = cookieGenerator.generateCookie("RefreshToken", refreshToken);
 
-        return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+        return ResponseEntity
+                .ok()
+                .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
                 .body(new RestResponse<>(response));
     }
 

--- a/src/main/java/com/noraknorak/user/presentation/dto/response/UserNewTokenResponse.java
+++ b/src/main/java/com/noraknorak/user/presentation/dto/response/UserNewTokenResponse.java
@@ -1,0 +1,12 @@
+package com.noraknorak.user.presentation.dto.response;
+
+public record UserNewTokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+
+    public static UserNewTokenResponse of(String accessToken, String refreshToken) {
+        return new UserNewTokenResponse(accessToken, refreshToken);
+    }
+
+}

--- a/src/main/java/com/noraknorak/user/presentation/dto/response/UserSignUpResponse.java
+++ b/src/main/java/com/noraknorak/user/presentation/dto/response/UserSignUpResponse.java
@@ -5,6 +5,7 @@ import com.noraknorak.user.domain.User;
 
 public record UserSignUpResponse(
         String accessToken,
+        String refreshToken,
         Long userId,
         String name,
         String birth,
@@ -13,9 +14,10 @@ public record UserSignUpResponse(
         Role role,
         boolean isNewUser
 ) {
-    public static UserSignUpResponse from(String accessToken, User user, boolean isNewUser) {
+    public static UserSignUpResponse from(String accessToken, String refreshToken, User user, boolean isNewUser) {
         return new UserSignUpResponse(
                 accessToken,
+                refreshToken,
                 user.getId(),
                 user.getName(),
                 user.getBirth(),

--- a/src/main/java/com/noraknorak/user/presentation/swagger/UserRegisterSwagger.java
+++ b/src/main/java/com/noraknorak/user/presentation/swagger/UserRegisterSwagger.java
@@ -1,17 +1,22 @@
 package com.noraknorak.user.presentation.swagger;
 
+import com.noraknorak.auth.exception.AuthenticationErrorCode;
 import com.noraknorak.core.config.swagger.ApiErrorCode;
 import com.noraknorak.core.config.swagger.SwaggerRequestBodyExample;
+import com.noraknorak.core.infrastructure.security.CustomUserDetails;
 import com.noraknorak.core.presentation.RestResponse;
 import com.noraknorak.user.exception.UserErrorCode;
 import com.noraknorak.user.presentation.dto.request.UserSignUpRequest;
 import com.noraknorak.user.presentation.dto.request.UserVerifyCodeRequest;
+import com.noraknorak.user.presentation.dto.response.UserNewTokenResponse;
 import com.noraknorak.user.presentation.dto.response.UserSignUpResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 
 @Tag(name = "Auth", description = "로그인/회원가입 관련 컨트롤러")
@@ -27,7 +32,6 @@ public interface UserRegisterSwagger {
     @ApiErrorCode(UserErrorCode.class)
     ResponseEntity<RestResponse<UserSignUpResponse>> signUp(@Valid @RequestBody UserSignUpRequest userSignUpRequest);
 
-    @Deprecated
     @Operation(
             summary = "문자 인증 API (사용 x)",
             description = "사용자로부터 코드를 받아 인증을 수행합니다. (사용 안함)",
@@ -35,4 +39,16 @@ public interface UserRegisterSwagger {
     )
     @ApiErrorCode(UserErrorCode.class)
     ResponseEntity<RestResponse<Boolean>> verifyCode(@Valid @RequestBody UserVerifyCodeRequest userVerifyCodeRequest);
+
+    @Operation(
+            summary = "토큰 재발급 API",
+            description = """
+                    refreshToken을 재발급합니다.
+                    """,
+            operationId = "v1/auth/reissue"
+    )
+    @ApiErrorCode({UserErrorCode.class, AuthenticationErrorCode.class})
+    ResponseEntity<RestResponse<UserNewTokenResponse>> issueNewToken(
+            @RequestHeader(value = "refreshToken", required = false) String refreshToken
+    );
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 리프레시 토큰 재발급 로직 추가
- 리프레시 토큰을 쿠키 및 레디스에서 관리합니다.
---

## ✏️ 관련 이슈
#53 

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 로그인, 회원가입 시 리프레시 토큰이 함께 발급되며, 두 개의 쿠키(액세스 토큰, 리프레시 토큰)가 응답에 포함됩니다.
    - 리프레시 토큰을 활용한 액세스 토큰 재발급(토큰 재발급 API)이 추가되었습니다.
- **기능 개선**
    - 로그아웃 시 액세스 토큰과 리프레시 토큰 쿠키가 모두 삭제되며, 서버에 저장된 리프레시 토큰도 함께 삭제됩니다.
- **응답 변경**
    - 회원가입 및 로그인 응답에 리프레시 토큰 정보가 추가되었습니다.
- **오류 처리**
    - 토큰이 존재하지 않을 때의 에러 코드가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->