### PR TITLE
Feat(#57): 회원 탈퇴 기능을 추가한다

### DIFF
--- a/src/main/java/com/noraknorak/auth/infrastructure/JwtTokenProvider.java
+++ b/src/main/java/com/noraknorak/auth/infrastructure/JwtTokenProvider.java
@@ -111,4 +111,10 @@ public class JwtTokenProvider implements TokenProvider {
                 .signWith(SECRET_KEY)
                 .compact();
     }
+    public long getRemainingTime(String token) {
+        Claims claims = getPayload(token);
+        Date expiration = claims.getExpiration();
+        return expiration.getTime() - System.currentTimeMillis();
+    }
+
 }

--- a/src/main/java/com/noraknorak/user/application/UserDeleteService.java
+++ b/src/main/java/com/noraknorak/user/application/UserDeleteService.java
@@ -1,0 +1,23 @@
+package com.noraknorak.user.application;
+
+import com.noraknorak.user.domain.repository.UserRepository;
+import com.noraknorak.user.exception.UserErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserDeleteService {
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void deleteUserById(Long userId) {
+        if (!userRepository.existsById(userId)) {
+            throw UserErrorCode.USER_NOT_FOUND.toException();
+        }
+        userRepository.deleteById(userId);
+    }
+}

--- a/src/main/java/com/noraknorak/user/domain/ChatLog.java
+++ b/src/main/java/com/noraknorak/user/domain/ChatLog.java
@@ -25,6 +25,6 @@ public class ChatLog extends BaseLongIdEntity {
     private String recommendedProgram;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", referencedColumnName = "id", insertable = false, updatable = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 }

--- a/src/main/java/com/noraknorak/user/domain/User.java
+++ b/src/main/java/com/noraknorak/user/domain/User.java
@@ -1,12 +1,16 @@
 package com.noraknorak.user.domain;
 
 import com.noraknorak.core.infrastructure.jpa.entity.BaseLongIdEntity;
+import com.noraknorak.schedule.domain.Schedule;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -34,6 +38,12 @@ public class User extends BaseLongIdEntity {
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private Personality personality;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<ChatLog> chatLogs = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Schedule> schedules = new ArrayList<>();
 
     @Column(name = "user_code", nullable = false, unique = true, updatable = false)
     private String userCode;

--- a/src/main/java/com/noraknorak/user/presentation/controller/UserDeleteController.java
+++ b/src/main/java/com/noraknorak/user/presentation/controller/UserDeleteController.java
@@ -1,0 +1,65 @@
+package com.noraknorak.user.presentation.controller;
+
+import com.noraknorak.auth.infrastructure.JwtTokenProvider;
+import com.noraknorak.core.infrastructure.security.CustomUserDetails;
+import com.noraknorak.core.presentation.RestResponse;
+import com.noraknorak.user.application.UserDeleteService;
+import com.noraknorak.user.presentation.swagger.UserDeleteSwagger;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.concurrent.TimeUnit;
+
+@RestController
+@RequestMapping("v1/user")
+@RequiredArgsConstructor
+public class UserDeleteController implements UserDeleteSwagger {
+
+    private final UserDeleteService userDeleteService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    @DeleteMapping("/delete")
+    public ResponseEntity<RestResponse<Void>> deleteUser(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            HttpServletRequest request
+    ) {
+        userDeleteService.deleteUserById(userDetails.getId());
+
+        String token = (String) request.getAttribute("accessToken");
+        if (token != null) {
+            long remainingTime = jwtTokenProvider.getRemainingTime(token);
+            redisTemplate.opsForValue().set("blacklist:" + token, "true", remainingTime, TimeUnit.MILLISECONDS);
+        }
+
+        ResponseCookie accessCookie = ResponseCookie.from("accessToken", "")
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .maxAge(0)
+                .build();
+
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", "")
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .maxAge(0)
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
+                .body(new RestResponse<>(null));
+    }
+}

--- a/src/main/java/com/noraknorak/user/presentation/swagger/UserDeleteSwagger.java
+++ b/src/main/java/com/noraknorak/user/presentation/swagger/UserDeleteSwagger.java
@@ -1,0 +1,31 @@
+package com.noraknorak.user.presentation.swagger;
+
+import com.noraknorak.core.config.swagger.ApiErrorCode;
+import com.noraknorak.core.infrastructure.security.CustomUserDetails;
+import com.noraknorak.core.presentation.RestResponse;
+import com.noraknorak.user.exception.UserErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name = "User", description = "유저 삭제 관련 API")
+public interface UserDeleteSwagger {
+    @Operation(
+            summary = "유저 삭제 API",
+            description = """
+                    로그인된 사용자를 삭제합니다.  
+                    연관된 성향(Personality), 일정(Schedule), 대화 기록(ChatLog)도 함께 삭제됩니다 (Cascade).  
+                    삭제 후 사용자는 더 이상 로그인할 수 없습니다.
+                    """,
+            operationId = "v1/user/delete"
+    )
+    @ApiErrorCode(UserErrorCode.class)
+    ResponseEntity<RestResponse<Void>> deleteUser(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            HttpServletRequest request
+    );
+
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 회원 탈퇴 기능을 추가한다.

---

## ✏️ 관련 이슈
#57

---

## 🎸 기타 사항 or 추가 코멘트
-실제로 사용하려고 하는 기능보다는 프론트 쪽에서 테스트할 때 유용하라고 만든 기능입니다. 그래도 실제로 구현할 수 있도록 만들었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 회원 탈퇴 기능이 추가되었습니다. 사용자는 자신의 계정을 삭제할 수 있으며, 관련된 일정 및 채팅 기록 등도 함께 삭제됩니다.
    - 탈퇴 시 사용 중인 토큰이 즉시 무효화되고, 브라우저의 인증 쿠키가 삭제됩니다.

- **문서화**
    - 회원 탈퇴 API에 대한 Swagger 문서가 추가되어, API 사용 방법과 응답 정보를 쉽게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->