### PR TITLE
Feat(#61): 회원 탈퇴시 연관되어 있는 정보도 삭제

### DIFF
--- a/src/main/java/com/noraknorak/user/application/UserDeleteService.java
+++ b/src/main/java/com/noraknorak/user/application/UserDeleteService.java
@@ -1,11 +1,14 @@
 package com.noraknorak.user.application;
 
+import com.noraknorak.user.domain.User;
 import com.noraknorak.user.domain.repository.UserRepository;
 import com.noraknorak.user.exception.UserErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +18,14 @@ public class UserDeleteService {
 
     @Transactional
     public void deleteUserById(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> UserErrorCode.USER_NOT_FOUND.toException());
+
+        List<User> relatedUsers = userRepository.findAllByRelatedUserId(userId);
+        for (User related : relatedUsers) {
+            related.clearRelation();
+        }
+
         if (!userRepository.existsById(userId)) {
             throw UserErrorCode.USER_NOT_FOUND.toException();
         }

--- a/src/main/java/com/noraknorak/user/application/UserDeleteService.java
+++ b/src/main/java/com/noraknorak/user/application/UserDeleteService.java
@@ -26,9 +26,6 @@ public class UserDeleteService {
             related.clearRelation();
         }
 
-        if (!userRepository.existsById(userId)) {
-            throw UserErrorCode.USER_NOT_FOUND.toException();
-        }
         userRepository.deleteById(userId);
     }
 }

--- a/src/main/java/com/noraknorak/user/domain/User.java
+++ b/src/main/java/com/noraknorak/user/domain/User.java
@@ -50,4 +50,9 @@ public class User extends BaseLongIdEntity {
 
     @Column(name = "related_user")
     private Long relatedUser;
+
+    public void clearRelation() {
+        this.relatedUser = null;
+        this.role = null;
+    }
 }

--- a/src/main/java/com/noraknorak/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/noraknorak/user/domain/repository/UserRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -25,4 +26,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
             @Param("role") Role role,
             @Param("relatedUser") Long relatedUser
     );
+    @Query("SELECT u FROM User u WHERE u.relatedUser = :relatedUserId")
+    List<User> findAllByRelatedUserId(@Param("relatedUserId") Long relatedUserId);
+
 }

--- a/src/main/java/com/noraknorak/user/presentation/swagger/UserDeleteSwagger.java
+++ b/src/main/java/com/noraknorak/user/presentation/swagger/UserDeleteSwagger.java
@@ -11,7 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestHeader;
 
-@Tag(name = "User", description = "유저 삭제 관련 API")
+@Tag(name = "User", description = "유저 관련 API")
 public interface UserDeleteSwagger {
     @Operation(
             summary = "유저 삭제 API",


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 회원 탈퇴할 때 남아있는 연관 정보들이 삭제되게 코드를 작성하였습니다.

---

## ✏️ 관련 이슈
#61 


---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자의 연관 관계를 해제하는 기능이 추가되었습니다.
- **버그 수정**
  - 사용자 삭제 시 연관된 사용자들의 관계가 올바르게 해제되도록 개선되었습니다.
- **문서**
  - Swagger API 태그 설명이 "유저 삭제 관련 API"에서 "유저 관련 API"로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->