### PR TITLE
feat: 관계 설정할 때 성향 태그를 가져오는 코드 작성

### DIFF
--- a/src/main/java/com/noraknorak/user/application/UserRelationService.java
+++ b/src/main/java/com/noraknorak/user/application/UserRelationService.java
@@ -2,6 +2,7 @@ package com.noraknorak.user.application;
 
 import com.noraknorak.core.config.exception.DomainException;
 import com.noraknorak.core.infrastructure.security.CustomUserDetails;
+import com.noraknorak.user.domain.Personality;
 import com.noraknorak.user.domain.Role;
 import com.noraknorak.user.domain.User;
 import com.noraknorak.user.domain.repository.UserRepository;
@@ -22,27 +23,50 @@ public class UserRelationService {
                 .orElseThrow(UserErrorCode.NOT_EQUAL_USER_CODE::toException);
     }
 
-    // 부모/자식 관계 설정
+    // 부모/자식 관계 설정 + 자식의 personality 태그를 부모로부터 복사
     @Transactional
-    public void verifyRelatedUser(CustomUserDetails customUserDetails, String role, Long relatedUserId){
+    public void verifyRelatedUser(CustomUserDetails customUserDetails, String role, Long relatedUserId) {
         Long userId = customUserDetails.getId();
 
         if (userId.equals(relatedUserId)) {
             throw UserErrorCode.SELF_RELATION_NOT_ALLOWED.toException();
         }
 
-        try{
-            if(Role.SENIOR.getName().equals(role)){
+        try {
+            User me = userRepository.findById(userId)
+                    .orElseThrow(UserErrorCode.USER_NOT_FOUND::toException);
+
+            User relatedUser = userRepository.findById(relatedUserId)
+                    .orElseThrow(UserErrorCode.USER_NOT_FOUND::toException);
+
+            if (Role.SENIOR.getName().equals(role)) {
                 userRepository.updateUserRoleAndRelatedUser(userId, Role.GUARDIAN, relatedUserId);
-            }else if(Role.GUARDIAN.getName().equals(role)){
+
+            } else if (Role.GUARDIAN.getName().equals(role)) {
                 userRepository.updateUserRoleAndRelatedUser(userId, Role.SENIOR, relatedUserId);
-            }else{
+
+                if (relatedUser.getPersonality() != null) {
+                    me.setPersonality(null);
+
+                    Personality copied = Personality.builder()
+                            .tag(relatedUser.getPersonality().getTag())
+                            .ei(relatedUser.getPersonality().getEi())
+                            .sn(relatedUser.getPersonality().getSn())
+                            .tf(relatedUser.getPersonality().getTf())
+                            .pj(relatedUser.getPersonality().getPj())
+                            .user(me)
+                            .build();
+
+                    me.setPersonality(copied);
+                }
+
+            } else {
                 throw UserErrorCode.INVALID_ROLE_ERROR.toException();
             }
+
         } catch (DomainException e) {
             throw e;
-        }
-        catch (Exception e){
+        } catch (Exception e) {
             throw UserErrorCode.INTERNAL_SERVER_ERROR.toException();
         }
     }

--- a/src/main/java/com/noraknorak/user/domain/User.java
+++ b/src/main/java/com/noraknorak/user/domain/User.java
@@ -55,4 +55,9 @@ public class User extends BaseLongIdEntity {
         this.relatedUser = null;
         this.role = null;
     }
+
+    public void setPersonality(Personality personality) {
+        this.personality = personality;
+    }
+
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 관계 설정할 때 부모의 성향 태그를 가져온다

---

## ✏️ 관련 이슈
#63 

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 역할이 "시니어" 또는 "가디언"일 때 사용자 역할 및 성격 정보가 상황에 따라 자동으로 연동 및 복사됩니다.

- **버그 수정**
  - 연결된 사용자가 존재하지 않을 경우 올바른 예외가 발생하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->