### PR TITLE
feat:내 일정과 관계가 설정된 사람의 일정도 함께 조회

### DIFF
--- a/src/main/java/com/noraknorak/schedule/application/UserScheduleService.java
+++ b/src/main/java/com/noraknorak/schedule/application/UserScheduleService.java
@@ -6,12 +6,18 @@ import com.noraknorak.schedule.domain.repository.ScheduleRepository;
 import com.noraknorak.schedule.exception.ScheduleErrorCode;
 import com.noraknorak.schedule.presentation.dto.response.UserScheduleDto;
 import com.noraknorak.schedule.util.ScheduleDateUtils;
+import com.noraknorak.user.domain.User;
+import com.noraknorak.user.domain.repository.UserRepository;
+import com.noraknorak.user.exception.UserErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -19,21 +25,35 @@ public class UserScheduleService {
 
     private final ScheduleRepository scheduleRepository;
     private final ImageUrlGenerator imageUrlGenerator;
+    private final UserRepository userRepository;
 
     @Transactional
     public List<UserScheduleDto> getDetailedSchedulesForUser(Long userId) {
-        List<Schedule> schedules = scheduleRepository.findByUserId(userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> UserErrorCode.USER_NOT_FOUND.toException());
 
-        if(schedules == null || schedules.isEmpty()) {
+        List<Long> userIdsToSearch = new ArrayList<>();
+        userIdsToSearch.add(userId);
+
+        if (user.getRelatedUser() != null) {
+            userIdsToSearch.add(user.getRelatedUser());
+        }
+
+        List<Schedule> schedules = scheduleRepository.findByUserIdIn(userIdsToSearch);
+
+        if (schedules.isEmpty()) {
             throw ScheduleErrorCode.SCHEDULE_NOT_FOUND.toException();
         }
 
-        return scheduleRepository.findByUserId(userId)
-                .stream()
+        // 중복 제거 기준: programId
+        Set<Long> seenProgramIds = new HashSet<>();
+        return schedules.stream()
+                .filter(schedule -> seenProgramIds.add(schedule.getProgram().getId()))
                 .map(schedule -> {
                     List<LocalDate> dates = ScheduleDateUtils.extractProgramDates(schedule.getProgram());
                     return UserScheduleDto.from(schedule, dates, imageUrlGenerator);
                 })
                 .toList();
     }
+
 }

--- a/src/main/java/com/noraknorak/schedule/application/UserScheduleService.java
+++ b/src/main/java/com/noraknorak/schedule/application/UserScheduleService.java
@@ -32,14 +32,14 @@ public class UserScheduleService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> UserErrorCode.USER_NOT_FOUND.toException());
 
-        List<Long> userIdsToSearch = new ArrayList<>();
+        Set<Long> userIdsToSearch = new HashSet<>();
         userIdsToSearch.add(userId);
 
         if (user.getRelatedUser() != null) {
             userIdsToSearch.add(user.getRelatedUser());
         }
 
-        List<Schedule> schedules = scheduleRepository.findByUserIdIn(userIdsToSearch);
+        List<Schedule> schedules = scheduleRepository.findByUserIdIn(new ArrayList<>(userIdsToSearch));
 
         if (schedules.isEmpty()) {
             throw ScheduleErrorCode.SCHEDULE_NOT_FOUND.toException();

--- a/src/main/java/com/noraknorak/schedule/domain/repository/ScheduleRepository.java
+++ b/src/main/java/com/noraknorak/schedule/domain/repository/ScheduleRepository.java
@@ -10,4 +10,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     List<Schedule> findByUserId(Long userId);
     boolean existsByUserIdAndProgramId(Long userId, Long programId);
     Optional<Schedule> findByIdAndUserId(Long scheduleId, Long userId);
+    List<Schedule> findByUserIdIn(List<Long> userIds);
+
 }

--- a/src/main/java/com/noraknorak/schedule/presentation/swagger/UserScheduleSwagger.java
+++ b/src/main/java/com/noraknorak/schedule/presentation/swagger/UserScheduleSwagger.java
@@ -16,8 +16,13 @@ import java.util.List;
 public interface UserScheduleSwagger {
 
     @Operation(
-            summary = "내가 등록한 일정 정보 조회 API",
-            description = "로그인한 사용자가 등록한 프로그램 목록과, 각 프로그램의 상세 정보 및 실제 날짜 목록을 조회합니다.",
+            summary = "일정 조회 API",
+            description = """
+                로그인한 사용자가 등록한 프로그램 목록을 조회합니다. 
+                만약 관계 설정(부모 또는 자식 관계)이 되어 있다면, 
+                관계 사용자가 등록한 일정도 함께 조회됩니다.
+                같은 프로그램에 중복으로 등록된 경우(예: 부모와 자식이 같은 프로그램 등록 시)는 한 번만 조회됩니다.
+                """,
             operationId = "v1/schedule/my-schedule"
     )
     @ApiErrorCode(ScheduleErrorCode.class)


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 내 정보와 관계가 설정된 사람의 일정도 함께 조회되게 작성


---

## ✏️ 관련 이슈
#65 

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자의 일정 조회 시, 연관된 사용자(부모 또는 자녀)의 일정도 함께 조회되며, 동일 프로그램 중복 등록은 한 번만 표시됩니다.

- **버그 수정**
  - 존재하지 않는 사용자 또는 일정이 없을 경우, 적절한 오류 메시지가 제공됩니다.

- **문서화**
  - 일정 조회 API의 설명이 더 명확하고 상세하게 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->