### PR TITLE
feat: 요일을 통한 일정 검색도 관계 설정한 유저의 일정까지 반환

### DIFF
--- a/src/main/java/com/noraknorak/schedule/application/ScheduleDayService.java
+++ b/src/main/java/com/noraknorak/schedule/application/ScheduleDayService.java
@@ -6,38 +6,55 @@ import com.noraknorak.schedule.domain.Schedule;
 import com.noraknorak.schedule.domain.repository.ScheduleRepository;
 import com.noraknorak.schedule.exception.ScheduleErrorCode;
 import com.noraknorak.schedule.presentation.dto.response.ScheduleDayDto;
+import com.noraknorak.user.domain.User;
+import com.noraknorak.user.domain.repository.UserRepository;
+import com.noraknorak.user.exception.UserErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ScheduleDayService {
 
     private final ScheduleRepository scheduleRepository;
+    private final UserRepository userRepository;
     private final ImageUrlGenerator imageUrlGenerator;
 
     @Transactional
     public List<ScheduleDayDto> getSchedulesByDay(Long userId, String dayKorean) {
-        List<Schedule> schedules = scheduleRepository.findByUserId(userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> UserErrorCode.USER_NOT_FOUND.toException());
 
-        if(schedules == null || schedules.isEmpty()) {
+        Set<Long> userIdsToSearch = new HashSet<>();
+        userIdsToSearch.add(user.getId());
+        if (user.getRelatedUser() != null) {
+            userIdsToSearch.add(user.getRelatedUser());
+        }
+
+        List<Schedule> schedules = scheduleRepository.findByUserIdIn(new ArrayList<>(userIdsToSearch));
+        if (schedules.isEmpty()) {
             throw ScheduleErrorCode.SCHEDULE_NOT_FOUND.toException();
         }
 
-        List<ScheduleDayDto> filtered = filteringScheduleByDays(
-                schedules,
-                dayKorean
-        );
-
+        List<ScheduleDayDto> filtered = filteringScheduleByDays(schedules, dayKorean);
         if (filtered.isEmpty()) {
             throw ScheduleErrorCode.NO_PROGRAM_FOR_DAY.toException();
         }
 
-        return filtered;
+        return filtered.stream()
+                .collect(Collectors.toMap(
+                        ScheduleDayDto::programId,
+                        Function.identity(),
+                        (d1, d2) -> d1
+                ))
+                .values()
+                .stream()
+                .toList();
     }
 
     private List<ScheduleDayDto> filteringScheduleByDays(List<Schedule> schedules, String dayKorean) {

--- a/src/main/java/com/noraknorak/schedule/presentation/swagger/ScheduleDaySwagger.java
+++ b/src/main/java/com/noraknorak/schedule/presentation/swagger/ScheduleDaySwagger.java
@@ -18,7 +18,7 @@ public interface ScheduleDaySwagger {
 
     @Operation(
             summary = "요일 기반 내 프로그램 조회",
-            description = "요청한 요일(월~일)에 해당하는 로그인 사용자의 프로그램 정보를 반환합니다.",
+            description = "요청한 요일(월~일)에 해당하는 로그인 사용자와 연관된 사용자의 프로그램 정보를 반환합니다.",
             operationId = "v1/schedule/my-schedule-day/{day}"
     )
     @ApiErrorCode(ScheduleErrorCode.class)


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 요일을 통한 일정 검색도 관계 설정한 유저의 일정까지 반환한다.

---

## ✏️ 관련 이슈
#67 

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 로그인한 사용자뿐만 아니라 관련 사용자들의 일정도 요일별로 함께 조회할 수 있도록 기능이 확장되었습니다.

- **문서**
  - 요일별 프로그램 조회 API 설명이 관련 사용자 일정도 포함하여 반환함을 명확히 안내하도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->