### PR TITLE
feat: 나의 일정과 관계 설정된 유저의 일정까지 삭제한다

### DIFF
--- a/src/main/java/com/noraknorak/schedule/application/ScheduleDeleteService.java
+++ b/src/main/java/com/noraknorak/schedule/application/ScheduleDeleteService.java
@@ -1,26 +1,41 @@
 package com.noraknorak.schedule.application;
 
-import com.noraknorak.core.config.exception.DomainException;
 import com.noraknorak.core.infrastructure.security.CustomUserDetails;
 import com.noraknorak.schedule.domain.Schedule;
 import com.noraknorak.schedule.domain.repository.ScheduleRepository;
 import com.noraknorak.schedule.exception.ScheduleErrorCode;
+import com.noraknorak.user.domain.User;
+import com.noraknorak.user.domain.repository.UserRepository;
+import com.noraknorak.user.exception.UserErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 public class ScheduleDeleteService {
 
     private final ScheduleRepository scheduleRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public void deleteScheduleById(CustomUserDetails customUserDetails, Long scheduleId) {
         Long userId = customUserDetails.user().getId();
 
-        Schedule schedule = scheduleRepository
-                .findByIdAndUserId(scheduleId, userId)
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> UserErrorCode.USER_NOT_FOUND.toException());
+
+        Set<Long> validUserIds = new HashSet<>();
+        validUserIds.add(user.getId());
+        if (user.getRelatedUser() != null) {
+            validUserIds.add(user.getRelatedUser());
+        }
+
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .filter(s -> validUserIds.contains(s.getUser().getId()))
                 .orElseThrow(() -> ScheduleErrorCode.SCHEDULE_NOT_FOUND.toException());
 
         scheduleRepository.delete(schedule);

--- a/src/main/java/com/noraknorak/schedule/presentation/swagger/ScheduleDeleteSwagger.java
+++ b/src/main/java/com/noraknorak/schedule/presentation/swagger/ScheduleDeleteSwagger.java
@@ -14,7 +14,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 @Tag(name = "Schedule", description = "일정 삭제 API")
 public interface ScheduleDeleteSwagger {
 
-    @Operation(summary = "내 일정 삭제", description = "로그인된 사용자가 등록한 특정 프로그램 일정을 삭제합니다.")
+    @Operation(summary = "일정 삭제", description = "로그인된 사용자와 관계 설정된 유저가 등록한 특정 프로그램 일정을 삭제합니다.")
     @ApiErrorCode(ScheduleErrorCode.class)
     ResponseEntity<RestResponse<Void>> deleteMySchedule(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 나의 일정과 관계 설정된 유저의 일정까지 삭제한다.

---

## ✏️ 관련 이슈
#69 

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 일정 삭제 시, 삭제 권한이 있는 사용자인지 추가로 검증하여 보다 정확한 권한 체크를 적용했습니다.  
- **문서화**
  - 일정 삭제 API의 설명을 실제 동작에 맞게 수정하여, 로그인한 사용자 또는 연관 사용자가 일정을 삭제할 수 있음을 명확히 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->