### PR TITLE
feat: 관계 삭제 및 기능을 추가한다.

### DIFF
--- a/src/main/java/com/noraknorak/user/application/UserRelationDeleteService.java
+++ b/src/main/java/com/noraknorak/user/application/UserRelationDeleteService.java
@@ -1,0 +1,31 @@
+package com.noraknorak.user.application;
+
+import com.noraknorak.core.infrastructure.security.CustomUserDetails;
+import com.noraknorak.user.domain.User;
+import com.noraknorak.user.domain.repository.UserRepository;
+import com.noraknorak.user.exception.UserErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserRelationDeleteService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void deleteRelation(CustomUserDetails customUserDetails) {
+        Long userId = customUserDetails.getId();
+        User me = userRepository.findById(userId)
+                .orElseThrow(UserErrorCode.USER_NOT_FOUND::toException);
+
+        if (me.getRelatedUser() != null) {
+            User relatedUser = userRepository.findById(me.getRelatedUser())
+                    .orElseThrow(UserErrorCode.USER_NOT_FOUND::toException);
+            userRepository.updateUserRoleAndRelatedUser(relatedUser.getId(), null, null);
+        }
+
+        userRepository.updateUserRoleAndRelatedUser(me.getId(), null, null);
+    }
+}

--- a/src/main/java/com/noraknorak/user/application/UserRelationService.java
+++ b/src/main/java/com/noraknorak/user/application/UserRelationService.java
@@ -41,6 +41,14 @@ public class UserRelationService {
             User relatedUser = userRepository.findById(relatedUserId)
                     .orElseThrow(UserErrorCode.USER_NOT_FOUND::toException);
 
+            if (me.getRole() != null && me.getRole().getName().equals(relatedUser.getRole().getName())) {
+                throw UserErrorCode.SAME_ROLE_RELATION_NOT_ALLOWED.toException();
+            }
+
+            if (relatedUser.getRelatedUser() != null) {
+                throw UserErrorCode.RELATED_USER_ALREADY_CONNECTED.toException();
+            }
+
             if (Role.SENIOR.getName().equals(role)) {
                 userRepository.updateUserRoleAndRelatedUser(userId, Role.SENIOR, relatedUserId);
                 userRepository.updateUserRoleAndRelatedUser(relatedUserId, Role.GUARDIAN, userId);
@@ -51,9 +59,8 @@ public class UserRelationService {
 
                 if (relatedUser.getPersonality() != null) {
                     Personality existingPersonality = me.getPersonality();
-                    System.out.println(existingPersonality);
                     if (existingPersonality != null) {
-                        personalityRepository.delete(existingPersonality); // or use orphanRemoval
+                        personalityRepository.delete(existingPersonality);
                         me.setPersonality(null);
                         personalityRepository.flush();
                     }

--- a/src/main/java/com/noraknorak/user/exception/UserErrorCode.java
+++ b/src/main/java/com/noraknorak/user/exception/UserErrorCode.java
@@ -17,6 +17,8 @@ public enum UserErrorCode implements BaseErrorCode {
     INVALID_RESIDENT_NUMBER(HttpStatus.BAD_REQUEST, "주민번호 양식이 잘못되었습니다."),
     NOT_EQUAL_USER_CODE(HttpStatus.NOT_FOUND, "부모/자식 정보를 찾을 수 없습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 오류 발생 -> 서버를 확인해주세요"),
+    SAME_ROLE_RELATION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "상대방과 같은 역할이므로 관계 설정이 불가능합니다."),
+    RELATED_USER_ALREADY_CONNECTED(HttpStatus.CONFLICT, "상대방 유저는 이미 다른 유저와 관계가 설정되어 있습니다."),
     INVALID_ROLE_ERROR(HttpStatus.BAD_REQUEST, "알 수 없는 역할 정보입니다. 정보를 정확히 입력해주세요");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/noraknorak/user/presentation/controller/UserRelationDeleteController.java
+++ b/src/main/java/com/noraknorak/user/presentation/controller/UserRelationDeleteController.java
@@ -1,0 +1,29 @@
+package com.noraknorak.user.presentation.controller;
+
+import com.noraknorak.core.infrastructure.security.CustomUserDetails;
+import com.noraknorak.core.presentation.RestResponse;
+import com.noraknorak.user.application.UserRelationDeleteService;
+import com.noraknorak.user.presentation.swagger.UserRelationDeleteSwagger;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/user/relation")
+@RequiredArgsConstructor
+public class UserRelationDeleteController implements UserRelationDeleteSwagger {
+
+    private final UserRelationDeleteService userRelationDeleteService;
+
+    @Override
+    @DeleteMapping("/delete")
+    public ResponseEntity<RestResponse<Boolean>> deleteRelation(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        userRelationDeleteService.deleteRelation(customUserDetails);
+        return ResponseEntity.ok(new RestResponse<>(true));
+    }
+}

--- a/src/main/java/com/noraknorak/user/presentation/swagger/UserRelationDeleteSwagger.java
+++ b/src/main/java/com/noraknorak/user/presentation/swagger/UserRelationDeleteSwagger.java
@@ -1,0 +1,22 @@
+package com.noraknorak.user.presentation.swagger;
+
+import com.noraknorak.core.infrastructure.security.CustomUserDetails;
+import com.noraknorak.core.presentation.RestResponse;
+import com.noraknorak.user.exception.UserErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Tag(name = "User", description = "유저 관계 삭제 API")
+public interface UserRelationDeleteSwagger {
+
+    @Operation(
+            summary = "부모/자식 관계 삭제 및 역할 삭제",
+            description = "자신 및 상대방 유저의 관계(relatedUser, role)를 모두 초기화합니다.",
+            operationId = "v1/user/relation/delete"
+    )
+    ResponseEntity<RestResponse<Boolean>> deleteRelation(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    );
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 관계 삭제하는 기능을 추가한다.
- 새로운 관계 설정 시 상대방이 관계가 설정되어 있으면 설정되지 못하게 한다.
- 관계 설정 시 같은 역할이면 설정하지 못하게 한다.

---

## ✏️ 관련 이슈
#71 

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 사용자의 관계 및 역할을 삭제할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
- **버그 수정**
  - 동일한 역할을 가진 사용자 간의 관계 설정이 제한되며, 이미 다른 사용자와 연결된 사용자는 추가 연결이 불가하도록 검증이 강화되었습니다.
- **문서화**
  - 사용자 관계 삭제 API에 대한 Swagger 문서가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->